### PR TITLE
change UI messages to go through capistrano logging

### DIFF
--- a/lib/cap-deploy-tagger/tasks/tagger.rake
+++ b/lib/cap-deploy-tagger/tasks/tagger.rake
@@ -3,10 +3,10 @@ namespace :deploy do
   desc "Tag deployed release"
   task :tag do
     if ENV['SKIP_DEPLOY_TAGGING'] || fetch(:skip_deploy_tagging, false)
-      puts "[cap-deploy-tagger] Skipped deploy tagging"
+      info "[cap-deploy-tagger] Skipped deploy tagging"
     else
       tag = CapDeployTagger::Helper.tag(fetch(:deploy_tag, "deployed"), fetch(:stage))
-      puts "[cap-deploy-tagger] Tagged #{CapDeployTagger::Helper.latest_revision} with #{tag}"
+      info "[cap-deploy-tagger] Tagged #{CapDeployTagger::Helper.latest_revision} with #{tag}"
     end
   end
   


### PR DESCRIPTION
This makes the messages capistrano log level `INFO` and can be controlled by the capistrano `:log_level` setting.
