### PR TITLE
don't create or push tag when sshkit is backend is SSHKit::Backend::Printer

### DIFF
--- a/lib/cap-deploy-tagger/tasks/tagger.rake
+++ b/lib/cap-deploy-tagger/tasks/tagger.rake
@@ -1,5 +1,5 @@
 namespace :deploy do
-  
+
   desc "Tag deployed release"
   task :tag do
     run_locally do
@@ -8,13 +8,15 @@ namespace :deploy do
       else
         tag_name = "#{fetch(:deploy_tag, "deployed")}_#{fetch(:stage)}"
         latest_revision = fetch(:current_revision)
-        strategy.git "tag -f #{tag_name} #{latest_revision}"
-        strategy.git "push -f --tags"
+        unless fetch(:sshkit_backend) ==  SSHKit::Backend::Printer # unless --dry-run flag present
+          strategy.git "tag -f #{tag_name} #{latest_revision}"
+          strategy.git "push -f --tags"
+        end
         info "[cap-deploy-tagger] Tagged #{latest_revision} with #{tag_name}"
       end
     end
   end
-  
+
   after :cleanup, 'deploy:tag'
-  
+
 end


### PR DESCRIPTION
fixes https://github.com/forward3d/cap-deploy-tagger/issues/6
