### PR TITLE
Replace strategy with execute to support capistrano 3.7+

### DIFF
--- a/lib/cap-deploy-tagger/tasks/tagger.rake
+++ b/lib/cap-deploy-tagger/tasks/tagger.rake
@@ -9,8 +9,8 @@ namespace :deploy do
         tag_name = "#{fetch(:deploy_tag, "deployed")}_#{fetch(:stage)}"
         latest_revision = fetch(:current_revision)
         unless fetch(:sshkit_backend) ==  SSHKit::Backend::Printer # unless --dry-run flag present
-          strategy.git "tag -f #{tag_name} #{latest_revision}"
-          strategy.git "push -f --tags"
+          execute :git, "tag -f #{tag_name} #{latest_revision}"
+          execute :git, "push -f --tags"
         end
         info "[cap-deploy-tagger] Tagged #{latest_revision} with #{tag_name}"
       end


### PR DESCRIPTION
Since Capistrano [changed its `strategy` system into plugins](https://github.com/capistrano/capistrano/blob/master/UPGRADING-3.7.md), this PR updates git calls to use `execute` 